### PR TITLE
Update findmeaccess.py -  fixed bug with optional proxy switch

### DIFF
--- a/findmeaccess.py
+++ b/findmeaccess.py
@@ -548,13 +548,13 @@ def main():
     if len(sys.argv) == 1:
       parser.print_help()
 
-    if args.proxy:
-      proxies = {
+    if getattr(args, 'proxy', None):
+        proxies = {
             "http": args.proxy, 
             "https": args.proxy
             }
     else:
-      proxies = {}
+        proxies = {}
     
     if args.command == "audit":
       if args.list_resources:


### PR DESCRIPTION
Fixed error when proxy switch was not supplied to the script: AttributeError: 'Namespace' object has no attribute 'proxy'

As the switch is optional, script should still be able to run without it