### PR TITLE
Add setup.py for pip/pipx compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup
+
+setup(
+    name="findmeaccess",
+    version="3.0",
+    install_requires=[ "tabulate", "termcolor", "requests", "lxml" ],
+    entry_points={ "console_scripts": [ "findmeaccess=findmeaccess:main" ] }
+)


### PR DESCRIPTION
# Summary

This tool currently lacks a setup.py, making it impossible to install via pip or pipx. Personally I prefer using pipx to isolate Python tools in separate virtual environments. Please note that this change does not break or prevent installation via the old method of `pip install -r requirements.txt` / `python findmeaccess.py`.

# Changes:

- Added minimal setup.py with:
  - Dependency specification (`install_requires=[ "tabulate", "termcolor", "requests", "lxml" ]`).
  - Console script entry point (`findmeaccess=findmeaccess:main`).

# Example Usage:
```
pipx (or pip) install git+https://github.com/absolomb/FindMeAccess
findmeaccess -h
```
