### PR TITLE
Update "Windows Phone" User-Agent

### DIFF
--- a/findmeaccess.py
+++ b/findmeaccess.py
@@ -112,7 +112,7 @@ user_agents = {
   "Windows 7 IE11": "Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko",
   "Windows 10 IE11": "Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko",
   "Windows 10 Edge": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36 Edg/121.0.2277.128",
-  "Windows Phone" : "Mozilla/5.0 (Windows Mobile 10; Android 10.0; Microsoft; Lumia 950XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Mobile Safari/537.36 Edge/40.15254.603"
+  "Windows Phone" : "Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; NOKIA; Lumia 800)"
 }
 
 # taken from TokenTacticsv2


### PR DESCRIPTION
Small fix. The "Android" string in the current Windows Phone agent gets detected as an Android device.